### PR TITLE
Fix contact links functionality in header section

### DIFF
--- a/packages/preview/silver-dev-cv/1.0.2/silver-dev-cv.typ
+++ b/packages/preview/silver-dev-cv/1.0.2/silver-dev-cv.typ
@@ -127,15 +127,20 @@
 
 // show contact details
 #let display(contacts) = {
-  set text(10pt, fill: headings-colour , weight: "regular", top-edge: "baseline", bottom-edge: "baseline", baseline: 2pt)
-  contacts
-    .map(contact => {
-        if ("link" in contact) {
-          link(contact.link)[#contact.text]
-        } else {
-          [#contact.text]
-        })
-    .join(" | ")
+  block(
+    spacing: 8pt,
+    {
+      set text(10pt, fill: headings-colour, weight: "regular")
+      contacts
+        .map(contact =>
+            if ("link" in contact) {
+              link(contact.link)[#contact.text]
+            } else {
+              [#contact.text]
+            })
+        .join(" | ")
+    }
+  )
 }
 
 #let cv(


### PR DESCRIPTION
Removes text baseline properties (`top-edge`, `bottom-edge`, `baseline`) that were breaking clickable links in the contact section. Wraps content in a block element with proper spacing to maintain consistent layout.